### PR TITLE
Add unit testing

### DIFF
--- a/lib/Respite/Base.pod
+++ b/lib/Respite/Base.pod
@@ -160,7 +160,7 @@ transport.)
 Can be one of new, cache, or morph.  Default is new.  When "new"
 is selected, a new object will be created with each dispatch call and
 it will contain a reference to the parent in the key named "base".  When
-"cached" is selected, a cached object will be used - the object is cached
+"cache" is selected, a cached object will be used - the object is cached
 inside of the base object.  When "morph is
 selected, rather than creating a new object, the base object is temporarily
 blessed into the new object class.

--- a/lib/Respite/Validate.pm
+++ b/lib/Respite/Validate.pm
@@ -223,6 +223,14 @@ sub validate_buddy {
         return @errors ? \@errors : 0;
     }
 
+    # allow for canonical field name (allows api to present one field name but return a different one)
+    # need to do this relatively early since we are changing the value of $field
+    if ($fv->{'canonical'}) {
+        my $orig = $fv->{'orig_field'} = $field;
+        $field = $fv->{'canonical'};
+        $form->{$field} = delete $form->{$orig};
+    }
+
     if ($fv->{'was_valid'}   && ! $self->{'was_valid'}->{$field})   { return [[$field_prefix.$field, 'was_valid',   $fv, $ifs_match]]; }
     if ($fv->{'had_error'}   && ! $self->{'had_error'}->{$field})   { return [[$field_prefix.$field, 'had_error',   $fv, $ifs_match]]; }
     if ($fv->{'was_checked'} && ! $self->{'was_checked'}->{$field}) { return [[$field_prefix.$field, 'was_checked', $fv, $ifs_match]]; }

--- a/t/Respite::Base.pm.t
+++ b/t/Respite::Base.pm.t
@@ -1,0 +1,288 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More qw(no_plan);
+use Throw qw(throw);
+use Respite::Base;
+use JSON ();
+
+use End;
+use File::Path qw(rmtree);
+my $dir = __FILE__.".testlib";
+#my $end = End->new(sub { rmtree $dir if -e $dir });
+mkdir $dir, or warn "Could not mkdir $dir: $!";
+open my $fh, '>', "$dir/MyMod.pm" or throw "Could not write $dir/MyMod.pm: $!";
+print $fh "package MyMod; use base 'Respite::Base'; sub __voom { return {VOOM => 1} }\n1;\n";
+mkdir "$dir/MyMod", or warn "Could not mkdir $dir/MyMod: $!";
+open $fh, '>', "$dir/MyMod/MySub.pm" or throw "Could not write $dir/MyMod/MySub.pm: $!";
+print $fh "package MyMod::MySub; use base 'MyMod'; our \$api_meta = {methods => {voom2 => 'voom2'}}; sub voom2 { return {VOOM2 => 1} }\n";
+close $fh;
+
+my $json = JSON->new->convert_blessed->allow_blessed->allow_nonref->canonical;
+
+my $file = __FILE__;
+$file =~ s|^(?:.+/)?lib/||;
+
+###----------------------------------------------------------------###
+
+{
+    package Bam;
+    use strict;
+    use Throw qw(throw);
+    use base qw(Respite::Base);
+    sub api_meta {
+        return shift->{'api_meta'} ||= {
+            dispatch_type => 'cache',
+            methods => {
+                foo => 'bar',
+            },
+            namespaces => {
+                foo_child  => 1,
+                bar_child  => 1,
+                baz_child  => 1,
+                bing_child => 1,
+                bang_child => 1,
+            },
+            lib_dirs => {
+                $dir => '__',
+            },
+        };
+    }
+
+    sub bar { {BAR => 1} }
+    sub bar__meta {} # { {desc => 'Bar desc'} }
+
+    sub val__meta {
+        return {desc => 'Bob', args => {foo => {required => 1, desc => 'Foo'}}};
+    }
+
+    our $val_line = __LINE__ + 3;
+    sub val {
+        my ($self, $args) = @_;
+        $self->validate_args($args);
+        return {ok => 1};
+    }
+
+
+    package FooChild;
+    sub new { bless $_[1] || {}, $_[0] }
+    sub one { {FOO_CHILD => 1} }
+    sub one__meta { {desc => ''} }
+
+    package BarChild;
+    sub new { bless $_[1] || {}, $_[0] }
+    sub two { {BAR_CHILD => 1} }
+    sub two__meta { return {desc => "Hey", args => {}, resp => {}} }
+
+    package BazChild;
+    sub new { bless $_[1] || {}, $_[0] }
+    sub three { {BAZ_CHILD => 1} }
+    sub three__meta { {desc => '3m'} }
+    sub __hey_non { {HEY_NON => 1} }
+    sub other {}
+
+    package BingChild;
+    use base qw(Respite::Base);
+    sub new { bless $_[1] || {}, $_[0] }
+#    sub api_meta { {methods => {bing_child => 'bing_child'}} }
+    sub __four { {BING_CHILD => 1} }
+
+    package BangChild;
+    sub new { bless $_[1] || {}, $_[0] }
+    sub __five { {BANG_CHILD => 1, self => "$_[0]", base => "".($_[0]->{'base'}||'')} }
+}
+
+###----------------------------------------------------------------###
+
+my $obj = eval { Respite::Base->new({api_meta => {}}) };
+my $out = eval { $obj->find_method } or diag "$@";
+is_deeply([sort keys %$out], [qw(--load-- hello hello__meta methods methods__meta)], 'Base lookup');
+is($out->{'hello'}, 'Respite::Base::__hello', "Correct lookup for hello");
+
+
+$obj = eval { Respite::Base->new({api_meta => {methods => {foo => 1, bar => 'bar', hello => 'myhello'}}}) };
+$out = eval { $obj->find_method } or diag "$@";
+is_deeply([sort keys %$out], [qw(--load-- bar foo hello hello__meta methods methods__meta)], 'Base lookup');
+is($out->{'bar'}, 'bar', "Correct lookup for bar");
+is($out->{'foo'}, 1, "Correct lookup for foo");
+is($out->{'hello'}, 'myhello', "Correct lookup for hello");
+
+$obj = eval { Respite::Base->new({
+    api_meta => {
+        methods => {
+            foo => 1,
+            bar => 'bar',
+            hello => 'myhello',
+        },
+        namespaces => {
+            bang_child => 1,
+        },
+    },
+}) };
+$out = eval { $obj->find_method } or diag "$@";
+is_deeply([sort keys %$out], [qw(--load-- bang_child_five bar foo hello hello__meta methods methods__meta)], 'Base lookup');
+like($out->{'bang_child_five'}, qr/^CODE/, "Correct lookup for bang_child_five");
+
+
+$obj = eval { Respite::Base->new({api_meta => {namespaces => {bang_child => {dispatch_type => 'new'}}}}) };
+my $data = eval { $obj->bang_child_five };
+is($data->{'base'}, "$obj", 'Correct parent');
+my $id = $data->{'self'};
+ok(!$obj->{'BangChild'}, "No cached child");
+$data = eval{ $obj->bang_child_five };
+isnt($data->{'self'}, $id, 'New child each time');
+
+$obj = eval { Respite::Base->new({api_meta => {namespaces => {bang_child => {dispatch_type => 'cache'}}}}) };
+$data = eval{ $obj->bang_child_five };
+is_deeply($data, {BANG_CHILD => 1, self => "$obj->{'BangChild'}", base => "$obj"}, 'Correct caching');
+ok($obj->{'BangChild'}, "Has cached child");
+$data = eval{ $obj->bang_child_five };
+is_deeply($data, {BANG_CHILD => 1, self => "$obj->{'BangChild'}", base => "$obj"}, 'Correct caching');
+
+$obj = eval { Respite::Base->new({api_meta => {namespaces => {bang_child => {dispatch_type => 'morph'}}}}) };
+$data = eval{ $obj->bang_child_five };
+(my $morph = "$obj") =~ s/^Respite::Base=/BangChild=/;
+is_deeply($data, {BANG_CHILD => 1, self => $morph, base => $morph}, 'Correct caching');
+ok(!$obj->{'BangChild'}, "No cached child");
+
+
+$obj = eval { Respite::Base->new({
+    api_meta => {
+        methods => {
+            foo => 1,
+            bar => 'bar',
+            hello => 'myhello',
+        },
+        lib_dirs => {
+            $dir => 1,
+        },
+    },
+}) };
+$out = eval { $obj->find_method } or diag "$@";
+#debug $out;
+is_deeply([sort keys %$out], [qw(--load-- bar foo hello hello__meta methods methods__meta my_mod_voom)], 'Base lookup');
+
+$obj = eval { Bam->new };
+$out = eval { $obj->find_method } or diag "$@";
+#debug $out;
+is_deeply([sort keys %$out], [qw(
+--load--
+bang_child_five
+bar
+bar__meta
+bar_child_two
+bar_child_two__meta
+baz_child_hey_non
+baz_child_three
+baz_child_three__meta
+bing_child_four
+foo
+foo_child_one
+foo_child_one__meta
+hello
+hello__meta
+methods
+methods__meta
+my_mod_voom
+val
+val__meta)], 'Base lookup');
+
+###----------------------------------------------------------------###
+
+$obj = eval { Bam->new } || diag "$@";
+ok($obj, "Created Respite::Base object");
+
+$out = eval { local $obj->api_meta->{'dispatch_type'} = 'cache'; $obj->methods } || diag "$@";
+is_deeply($out, {
+    methods => {
+        bar_child_two => "Hey",
+        bar => 'Not documented', # message from methods method call
+        baz_child_three => '3m',
+        foo_child_one => '',
+        hello => "Basic call to test connection",
+        methods => "Return a list of all known Bam methods.  Optionally return all meta information as well",
+        val => "Bob",
+    },
+}, "Check for proper methods listing") || do { debug $out;  };
+
+
+ok($obj->can('run_method'), "Can dispatch");
+my $sub_line = __LINE__ + 3;
+my $test = sub {
+    my ($method, $args, $resp) = @_;
+    my $data = eval { $obj->$method($args) };
+    $data ||= ref($@) ? $@->TO_JSON : diag "Trouble running $method: $@";
+
+    is_deeply($data, $resp, "$method(".$json->encode($args).")  ==> ".$json->encode($resp)) || do { debug $data;  };
+};
+eval { $obj->bang_child_five() }; # make sure a method has been called so the cache will hit and BangChild will be set
+
+$test->(@$_) for (
+    [foo => {} => {BAR => 1}],
+    [bar => {} => {BAR => 1}],
+    [bad => {} => {error => 'Invalid API method during AUTOLOAD', method => 'bad', class => 'Bam', trace => "Called from (eval) at $file line $sub_line"}],
+    [foo_child_one => {} => {FOO_CHILD => 1}],
+    [bar_child_two => {} => {BAR_CHILD => 1}],
+    [baz_child_three => {} => {BAZ_CHILD => 1}],
+    [baz_child_hey_non => {} => {HEY_NON => 1}],
+    [bing_child_four => {} => {BING_CHILD => 1}],
+    [bang_child_five => {} => {BANG_CHILD => 1, self => "$obj->{'BangChild'}", base => "$obj"}],
+
+    [val => {_no_trace => 1} => {type => 'validation', error => 'Failed to validate args', errors => {foo => 'foo is required.'}, trace => "Called from Bam::val at $file line $Bam::val_line"}],
+    [val => {_no_trace => 1, foo => 2} => {ok => 1}],
+    [val => {foo => 2} => {ok => 1}],
+    );
+
+###----------------------------------------------------------------###
+
+{
+    package Nest;
+    use strict;
+    use Throw qw(throw);
+    use base qw(Respite::Base);
+    sub foo__meta {{desc => 'nest foo'}}
+    sub foo { {n=>__PACKAGE__} }
+    sub api_meta {
+        shift->{'api_meta'} ||= {
+            allow_nested => 1,
+            namespaces => {
+                nest_a => 1,
+            },
+        };
+    }
+
+    package NestA;
+    use strict;
+    use Throw qw(throw);
+    use base qw(Nest);
+    sub foo__meta {{desc => 'nest_a foo'}}
+    sub foo { {n=>__PACKAGE__} }
+    sub api_meta {
+        shift->{'api_meta'} ||= {
+            namespaces => {
+                nest_b => 1,
+            },
+        };
+    }
+
+    package NestB;
+    use base qw(Respite::Base);
+    sub foo__meta {{desc => 'nest_b foo'}}
+    sub foo { {n=>__PACKAGE__} }
+}
+
+$obj = Nest->new({flat => 1});
+is(eval{$obj->foo->{'n'}}||'', 'Nest', "Correct base");
+is(eval{$obj->nest_a_foo->{'n'}}||'', 'NestA', "Correct child") || diag "$@";
+is(eval{$obj->nest_a_nest_b_foo->{'n'}}||'', 'NestB', "Correct grandchild") || diag "$@";
+$out = eval { $obj->methods } || diag "$@";
+is_deeply([sort keys %{$out->{'methods'}}], [qw(
+foo
+hello
+methods
+nest_a_foo
+nest_a_hello
+nest_a_methods
+nest_a_nest_b_foo
+)], "Correct nested setup");

--- a/t/Respite::Validate.pm.t
+++ b/t/Respite::Validate.pm.t
@@ -1,0 +1,652 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 232;
+
+use_ok('Respite::Validate');
+
+my $v;
+my $e;
+
+sub validate { scalar Respite::Validate->new->validate(@_) }
+
+### required
+$v = {foo => {required => 1, alias => 'ffoooo'}};
+$e = validate({}, $v);
+ok($e, 'required => 1 - fail');
+
+$e = validate({foo => 1}, $v);
+ok(! $e, 'required => 1 - good');
+
+$e = validate({ffoooo => 1}, $v);
+ok(! $e, 'required => 1 (with alias) - good');
+
+### validate_if
+$v = {foo => {required => 1, validate_if => 'bar'}};
+$e = validate({}, $v);
+ok(! $e, 'validate_if - true');
+
+$e = validate({bar => 1}, $v);
+ok($e, 'validate_if - false');
+
+$v = {text1 => {required => 1, validate_if => 'text2 was_valid'}, text2 => {validate_if => 'text3'}};
+$e = validate({}, $v);
+ok(! $e, "Got no error on validate_if with was_valid");
+$e = validate({text2 => 1}, $v);
+ok(! $e, "Got no error on validate_if with was_valid with non-validated data");
+$e = validate({text3 => 1}, $v);
+ok(! $e, "Got no error on validate_if with was_valid with validated - bad data");
+$e = validate({text2 => 1, text3 => 1}, $v);
+ok(! $e, "Got error on validate_if with was_valid with validated - good data");
+$e = validate({text1 => 1, text2 => 1, text3 => 1}, $v);
+ok(! $e, "No error on validate_if with was_valid with validated - good data");
+
+$v = {text1 => {required => 1, validate_if => 'text2 had_error'}, text2 => {required => 1}};
+$e = validate({}, $v);
+ok($e, "Got error on validate_if with had_error");
+$e = validate({text2 => 1}, $v);
+ok(! $e, "No error on validate_if with had_error and bad_data");
+$e = validate({text1 => 1}, $v);
+ok($e && ! $e->{'text1'}, "No error on validate_if with had_error and good data");
+
+$e = validate({text1 => ""}, {'m/^(tex)t1$/' => {required => 1, validate_if => '$1t2'}});
+ok(!$e, "validate_ifstr - no error");
+
+$e = validate({text1 => "", text2 => 1}, {'m/^(tex)t1$/' => {required => 1, validate_if => '$1t2'}});
+ok($e, "validate_ifstr - had error");
+
+$e = validate({text1 => ""}, {'m/^(tex)t1$/' => {required => 1, validate_if => {field => '$1t2',required => 1}}});
+ok(!$e, "validate_if - no error");
+
+$e = validate({text1 => "", text2 => 1}, {'m/^(tex)t1$/' => {required => 1, validate_if => {field => '$1t2',required => 1}}});
+ok($e, "validate_if - had error");
+
+$e = validate({text1 => ""}, {'m/^(tex)t1$/' => {required => 1, validate_if => '$1t2 was_valid'}});
+ok(!$e, "was valid - no error");
+
+$e = validate({text1 => "", text2 => 1}, {'m/^(tex)t1$/' => {required => 1, validate_if => '$1t2 was_valid'}});
+ok(!$e, "was valid - no error");
+
+$e = validate({text1 => "", text2 => 1}, {'m/^(tex)t1$/' => {required => 1, validate_if => '$1t2 was_valid'}, text2 => {required => 1}, 'group order' => [qw(text2)]});
+ok($e, "was valid - had error");
+
+### required_if
+$v = {foo => {required_if => 'bar'}};
+$e = validate({}, $v);
+ok(! $e, 'required_if - false');
+
+$e = validate({bar => 1}, $v);
+ok($e , 'required_if - true');
+
+### max_values
+$v = {foo => {required => 1}};
+$e = validate({foo => [1,2]}, $v);
+ok($e, 'max_values');
+
+$v = {foo => {max_values => 2}};
+$e = validate({}, $v);
+ok(! $e, 'max_values');
+
+$e = validate({foo => "str"}, $v);
+ok(! $e, 'max_values');
+
+$e = validate({foo => [1]}, $v);
+ok(! $e, 'max_values');
+
+$e = validate({foo => [1,2]}, $v);
+ok(! $e, 'max_values');
+
+$e = validate({foo => [1,2,3]}, $v);
+ok($e, 'max_values');
+
+### min_values
+$v = {foo => {min_values => 3, max_values => 10}};
+$e = validate({foo => [1,2,3]}, $v);
+ok(! $e, 'min_values');
+
+$e = validate({foo => [1,2,3,4]}, $v);
+ok(! $e, 'min_values');
+
+$e = validate({foo => [1,2]}, $v);
+ok($e, 'min_values');
+
+$e = validate({foo => "str"}, $v);
+ok($e, 'min_values');
+
+$e = validate({}, $v);
+ok($e, 'min_values');
+
+### enum
+$v = {foo => {enum => [1, 2, 3]}, bar => {enum => "1 || 2||3"}};
+$e = validate({}, $v);
+ok($e, 'enum');
+
+$e = validate({foo => 1, bar => 1}, $v);
+ok(! $e, 'enum');
+
+$e = validate({foo => 1, bar => 2}, $v);
+ok(! $e, 'enum');
+
+$v->{'foo'}->{'match'} = 'm/3/';
+$e = validate({foo => 1, bar => 2}, $v);
+ok($e, 'enum');
+is($e->{'foo'}, "foo contains invalid characters.", 'enum shortcircuit');
+
+$e = validate({foo => 4, bar => 1}, $v);
+ok($e, 'enum');
+is($e->{'foo'}, "foo is not in the given list.", 'enum shortcircuit');
+
+# equals
+$v = {foo => {equals => 'bar'}};
+$e = validate({}, $v);
+ok(! $e, 'equals');
+
+$e = validate({foo => 1}, $v);
+ok($e, 'equals');
+
+$e = validate({bar => 1}, $v);
+ok($e, 'equals');
+
+$e = validate({foo => 1, bar => 2}, $v);
+ok($e, 'equals');
+
+$e = validate({foo => 1, bar => 1}, $v);
+ok(! $e, 'equals');
+
+$v = {foo => {equals => '"bar"'}};
+$e = validate({foo => 1, bar => 1}, $v);
+ok($e, 'equals');
+
+$e = validate({foo => 'bar', bar => 1}, $v);
+ok(! $e, 'equals');
+
+$e = validate({text1 => "foo", text2 =>  "bar"}, {'m/^(tex)t1$/' => {equals => '$1t2'}});
+ok($e, "equals - had error");
+
+$e = validate({text1 => "foo", text2 => "foo"}, {'m/^(tex)t1$/' => {equals => '$1t2'}});
+ok(!$e, "equals - no error");
+
+
+### min_len
+$v = {foo => {min_len => 10}};
+$e = validate({}, $v);
+ok($e, 'min_len');
+
+$e = validate({foo => ""}, $v);
+ok($e, 'min_len');
+
+$e = validate({foo => "123456789"}, $v);
+ok($e, 'min_len');
+
+$e = validate({foo => "1234567890"}, $v);
+ok(! $e, 'min_len');
+
+### max_len
+$v = {foo => {max_len => 10}};
+$e = validate({}, $v);
+ok(! $e, 'max_len');
+
+$e = validate({foo => ""}, $v);
+ok(! $e, 'max_len');
+
+$e = validate({foo => "1234567890"}, $v);
+ok(! $e, 'max_len');
+
+$e = validate({foo => "12345678901"}, $v);
+ok($e, 'max_len');
+
+### match
+$v = {foo => {match => qr/^\w+$/}};
+$e = validate({foo => "abc"}, $v);
+ok(! $e, 'match');
+
+$e = validate({foo => "abc."}, $v);
+ok($e, 'match');
+
+$v = {foo => {match => [qr/^\w+$/, qr/^[a-z]+$/]}};
+$e = validate({foo => "abc"}, $v);
+ok(! $e, 'match');
+
+$e = validate({foo => "abc1"}, $v);
+ok($e, 'match');
+
+$v = {foo => {match => 'm/^\w+$/'}};
+$e = validate({foo => "abc"}, $v);
+ok(! $e, 'match');
+
+$e = validate({foo => "abc."}, $v);
+ok($e, 'match');
+
+$v = {foo => {match => 'm/^\w+$/ || m/^[a-z]+$/'}};
+$e = validate({foo => "abc"}, $v);
+ok(! $e, 'match');
+
+$e = validate({foo => "abc1"}, $v);
+ok($e, 'match');
+
+$v = {foo => {match => '! m/^\w+$/'}};
+$e = validate({foo => "abc"}, $v);
+ok($e, 'match');
+
+$e = validate({foo => "abc."}, $v);
+ok(! $e, 'match');
+
+$v = {foo => {match => 'm/^\w+$/'}};
+$e = validate({}, $v);
+ok($e, 'match');
+
+$v = {foo => {match => '! m/^\w+$/'}};
+$e = validate({}, $v);
+ok(! $e, 'match');
+
+### compare
+$v = {foo => {compare => '> 0'}};
+$e = validate({}, $v);
+ok($e, 'compare');
+$v = {foo => {compare => '== 0'}};
+$e = validate({}, $v);
+ok(! $e, 'compare');
+$v = {foo => {compare => '< 0'}};
+$e = validate({}, $v);
+ok($e, 'compare');
+
+$v = {foo => {compare => '> 10'}};
+$e = validate({foo => 11}, $v);
+ok(! $e, 'compare');
+$e = validate({foo => 10}, $v);
+ok($e, 'compare');
+
+$v = {foo => {compare => '== 10'}};
+$e = validate({foo => 11}, $v);
+ok($e, 'compare');
+$e = validate({foo => 10}, $v);
+ok(! $e, 'compare');
+
+$v = {foo => {compare => '< 10'}};
+$e = validate({foo => 9}, $v);
+ok(! $e, 'compare');
+$e = validate({foo => 10}, $v);
+ok($e, 'compare');
+
+$v = {foo => {compare => '>= 10'}};
+$e = validate({foo => 10}, $v);
+ok(! $e, 'compare');
+$e = validate({foo => 9}, $v);
+ok($e, 'compare');
+
+$v = {foo => {compare => '!= 10'}};
+$e = validate({foo => 10}, $v);
+ok($e, 'compare');
+$e = validate({foo => 9}, $v);
+ok(! $e, 'compare');
+
+$v = {foo => {compare => '<= 10'}};
+$e = validate({foo => 11}, $v);
+ok($e, 'compare');
+$e = validate({foo => 10}, $v);
+ok(! $e, 'compare');
+
+
+$v = {foo => {compare => 'gt ""'}};
+$e = validate({}, $v);
+ok($e, 'compare');
+$v = {foo => {compare => 'eq ""'}};
+$e = validate({}, $v);
+ok(! $e, 'compare');
+$v = {foo => {compare => 'lt ""'}};
+$e = validate({}, $v);
+ok($e, 'compare'); # 68
+
+$v = {foo => {compare => 'gt "c"'}};
+$e = validate({foo => 'd'}, $v);
+ok(! $e, 'compare');
+$e = validate({foo => 'c'}, $v);
+ok($e, 'compare');
+
+$v = {foo => {compare => 'eq c'}};
+$e = validate({foo => 'd'}, $v);
+ok($e, 'compare');
+$e = validate({foo => 'c'}, $v);
+ok(! $e, 'compare');
+
+$v = {foo => {compare => 'lt c'}};
+$e = validate({foo => 'b'}, $v);
+ok(! $e, 'compare');
+$e = validate({foo => 'c'}, $v);
+ok($e, 'compare');
+
+$v = {foo => {compare => 'ge c'}};
+$e = validate({foo => 'c'}, $v);
+ok(! $e, 'compare');
+$e = validate({foo => 'b'}, $v);
+ok($e, 'compare');
+
+$v = {foo => {compare => 'ne c'}};
+$e = validate({foo => 'c'}, $v);
+ok($e, 'compare');
+$e = validate({foo => 'b'}, $v);
+ok(! $e, 'compare');
+
+$v = {foo => {compare => 'le c'}};
+$e = validate({foo => 'd'}, $v);
+ok($e, 'compare');
+$e = validate({foo => 'c'}, $v);
+ok(! $e, 'compare');
+
+
+$v = {foo => {compare => 'le field:bar'}};
+$e = validate({foo => 'd', bar => 'c'}, $v);
+ok($e, 'compare');
+$e = validate({foo => 'c', bar => 'c'}, $v);
+ok(! $e, 'compare');
+$e = validate({foo => 'c'}, $v);
+ok($e, 'compare') || debug $e;
+$e = validate({foo => ''}, $v);
+ok(!$e, 'compare') || debug $e;
+
+
+$v = {foo => {compare => '<= field:bar'}};
+$e = validate({foo => 3, bar => 2}, $v);
+ok($e, 'compare');
+$e = validate({foo => 2, bar => 2}, $v);
+ok(! $e, 'compare');
+$e = validate({foo => 2}, $v);
+ok($e, 'compare') || debug $e;
+$e = validate({foo => 0}, $v);
+ok(!$e, 'compare') || debug $e;
+
+### sql
+### can't really do anything here without prompting for a db connection
+
+### custom
+my $n = 1;
+$v = {foo => {custom => $n}};
+$e = validate({}, $v);
+ok(! $e, 'custom');
+$e = validate({foo => "str"}, $v);
+ok(! $e, 'custom');
+
+$n = 0;
+$v = {foo => {custom => $n}};
+$e = validate({}, $v);
+ok($e, 'custom');
+$e = validate({foo => "str"}, $v);
+ok($e, 'custom');
+
+$n = sub { my ($key, $val) = @_; return defined($val) ? 1 : 0};
+$v = {foo => {custom => $n}};
+$e = validate({}, $v);
+ok($e, 'custom');
+$e = validate({foo => "str"}, $v);
+ok(! $e, 'custom');
+
+$e = validate({foo => "str"}, {foo => {custom => sub { my ($k, $v) = @_; die "Always fail ($v)\n" }}});
+ok($e, 'Got an error');
+is($e->{'foo'}, "Always fail (str)", "Passed along the message from die");
+
+### type checks
+$v = {foo => {type => 'ip', match => 'm/^203\./'}};
+$e = validate({foo => '209.108.25'}, $v);
+ok($e, 'type ip');
+is($e->{'foo'}, 'foo did not match type ip.', 'type ip'); # make sure they short circuit
+$e = validate({foo => '209.108.25.111'}, $v);
+ok($e, 'type ip - but had match error');
+is($e->{'foo'}, 'foo contains invalid characters.', 'type ip');
+$e = validate({foo => '203.108.25.111'}, $v);
+ok(! $e, 'type ip');
+
+$v = {foo => {type => 'domain'}};
+$e = validate({foo => 'bar.com'}, $v);
+ok(! $e, 'type domain');
+$e = validate({foo => 'bing.bar.com'}, $v);
+ok(! $e, 'type domain');
+$e = validate({foo => 'bi-ng.com'}, $v);
+ok(! $e, 'type domain');
+$e = validate({foo => '123456789012345678901234567890123456789012345678901234567890123.com'}, $v);
+ok(! $e, 'type domain');
+
+$e = validate({foo => 'com'}, $v);
+ok($e, 'type domain');
+$e = validate({foo => 'bi-.com'}, $v);
+ok($e, 'type domain');
+$e = validate({foo => 'bi..com'}, $v);
+ok($e, 'type domain');
+$e = validate({foo => '1234567890123456789012345678901234567890123456789012345678901234.com'}, $v);
+ok($e, 'type domain');
+
+ok(!validate({n => $_}, {n => {type => 'num'}}),  "Type num $_")  for qw(0 2 23 -0 -2 -23 0.0 .1 0.1 0.10 1.0 1.01);
+ok(!validate({n => $_}, {n => {type => 'int'}}),  "Type int $_")  for qw(0 2 23 -0 -2 -23 2147483647 -2147483648);
+ok(!validate({n => $_}, {n => {type => 'uint'}}), "Type uint $_") for qw(0 2 23 4294967295);
+ok(validate({n => $_}, {n => {type  => 'num'}}),  "Type num invalid $_")  for qw(0a a2 -0a 0..0 00 001 1.);
+ok(validate({n => $_}, {n => {type  => 'int'}}),  "Type int invalid $_")  for qw(1.1 0.1 0.0 -1.1 0a a2 a 00 001 2147483648 -2147483649);
+ok(validate({n => $_}, {n => {type  => 'uint'}}), "Type uint invalid $_") for qw(-1 -0 1.1 0.1 0.0 -1.1 0a a2 a 00 001 4294967296);
+
+### min_in_set checks
+$v = {foo => {min_in_set => '2 of foo bar baz', max_values => 5}};
+$e = validate({foo => 1}, $v);
+ok($e, 'min_in_set');
+$e = validate({foo => 1, bar => 1}, $v);
+ok(! $e, 'min_in_set');
+$e = validate({foo => 1, bar => ''}, $v); # empty string doesn't count as value
+ok($e, 'min_in_set');
+$e = validate({foo => 1, bar => 0}, $v);
+ok(! $e, 'min_in_set');
+$e = validate({foo => [1, 2]}, $v);
+ok(! $e, 'min_in_set');
+$e = validate({foo => [1]}, $v);
+ok($e, 'min_in_set');
+$v = {foo => {min_in_set => '2 foo bar baz', max_values => 5}};
+$e = validate({foo => 1, bar => 1}, $v);
+ok(! $e, 'min_in_set');
+
+### max_in_set checks
+$v = {foo => {max_in_set => '2 of foo bar baz', max_values => 5}};
+$e = validate({foo => 1}, $v);
+ok(! $e, 'max_in_set');
+$e = validate({foo => 1, bar => 1}, $v);
+ok(! $e, 'max_in_set');
+$e = validate({foo => 1, bar => 1, baz => 1}, $v);
+ok($e, 'max_in_set');
+$e = validate({foo => [1, 2]}, $v);
+ok(! $e, 'max_in_set');
+$e = validate({foo => [1, 2, 3]}, $v);
+ok($e, 'max_in_set');
+
+### validate_if revisited (but negated - uses max_in_set)
+$v = {foo => {required => 1, validate_if => '! bar'}};
+$e = validate({}, $v);
+ok($e, 'validate_if - negated');
+
+$e = validate({bar => 1}, $v);
+ok(! $e, 'validate_if - negated');
+
+### default value
+my $f = {};
+$v = {foo => {required => 1, default => 'hmmmm'}};
+$e = validate($f, $v);
+ok(! $e, 'default');
+
+ok($f->{foo} && $f->{foo} eq 'hmmmm', 'had right default');
+
+### canonical field name
+$f = {foo => 'test'};
+$v = {foo => {required => 1, canonical => 'ffoooo'}};
+$e = validate($f, $v);
+ok(! $e, 'canonical');
+ok($f->{'ffoooo'} && $f->{'ffoooo'} eq 'test', 'returned canonical field name');
+ok(! $f->{'foo'}, 'did not return non-canonical field name');
+
+
+
+
+
+
+###----------------------------------------------------------------###
+
+### test single group for extra fields
+$v = {
+  'group no_extra_fields' => 1,
+  foo => {max_len => 10},
+};
+
+$e = validate({}, $v);
+ok(! $e);
+
+$e = validate({foo => "foo"}, $v);
+ok(! $e);
+
+$e = validate({foo => "foo", bar => "bar"}, $v);
+ok($e);
+
+$e = validate({bar => "bar"}, $v);
+ok($e);
+
+
+### test on failed validate if
+$v = {
+  'group no_extra_fields' => 1,
+  'group validate_if' => 'baz',
+  foo => {max_len => 10},
+};
+
+$e = validate({}, $v);
+ok(! $e);
+
+$e = validate({foo => "foo"}, $v);
+ok(! $e);
+
+$e = validate({foo => "foo", bar => "bar"}, $v);
+ok(! $e);
+
+$e = validate({bar => "bar"}, $v);
+ok(! $e);
+
+### test on successful validate if
+$v = {
+  'group no_extra_fields' => 1,
+  'group validate_if' => 'baz',
+  foo => {max_len => 10},
+  baz => {max_len => 10},
+};
+
+$e = validate({baz => 1}, $v);
+ok(! $e);
+
+$e = validate({baz => 1, foo => "foo"}, $v);
+ok(! $e);
+
+$e = validate({baz => 1, foo => "foo", bar => "bar"}, $v);
+ok($e);
+
+$e = validate({baz => 1, bar => "bar"}, $v);
+ok($e);
+
+
+
+
+###----------------------------------------------------------------###
+
+$v = {
+  foo => {
+    max_len => 10,
+    replace => 's/[^\d]//g',
+  },
+};
+
+$e = validate({
+  foo => '123-456-7890',
+}, $v);
+ok(! $e, "Didn't get error");
+
+
+my $form = {
+  key1 => 'Bu-nch @of characte#rs^',
+  key2 => '123 456 7890',
+  key3 => '123',
+};
+
+
+$v = {
+  key1 => {
+    replace => 's/[^\s\w]//g',
+  },
+};
+
+$e = validate($form, $v);
+ok(! $e, "No error");
+is($form->{'key1'}, 'Bunch of characters',  "key1 updated");
+
+$v = {
+  key2 => {
+    replace => 's/(\d{3})\D*(\d{3})\D*(\d{4})/($1) $2-$3/g',
+  },
+};
+
+$e = validate($form, $v);
+ok(! $e, "No error");
+is($form->{'key2'}, '(123) 456-7890', "Phone updated");
+
+$v = {
+  key2 => {
+    replace => 's/.+//g',
+    required => 1,
+  },
+};
+
+$e = validate($form, $v);
+ok($e, "Error");
+is($form->{'key2'}, '', "All replaced");
+
+$v = {
+    key3 => {
+        replace => 's/\d//',
+    },
+};
+$e = validate($form, $v);
+ok(! $e, "No error");
+is($form->{'key3'}, '23', "Non-global is fine");
+
+###----------------------------------------------------------------###
+
+$v = {
+    foo => {
+        type => {
+            baz => {required => 1}, # required only if "foo" exists
+        },
+    },
+};
+$e = validate({}, $v);
+ok(! $e, "Type hash, optional check");
+
+$e = validate({foo => 1}, $v);
+is_deeply($e, {foo => 'foo did not match type hash.'}, "Type hash, type check");
+
+$e = validate({foo => {}}, $v);
+is_deeply($e, {'foo.baz' => 'foo.baz is required.'}, "Type hash, inner required check");
+
+$e = validate({foo => {baz => 1}}, $v);
+ok(! $e, "Type hash, inner required ok");
+
+$v = {
+    foo => {
+        max_values => 2,
+        type => {
+            baz => {required => 1}, # required only if "foo" exists
+        },
+    },
+};
+$e = validate({foo => {baz => 1}}, $v);
+ok(! $e, "Type hash, array 1 element ok");
+
+$e = validate({foo => []}, $v);
+ok(! $e, "Type hash, array 0 elements ok");
+
+$e = validate({foo => [{baz => 1},{baz=>2}]}, $v);
+ok(! $e, "Type hash, array 2 elements ok");
+
+$e = validate({foo => [{baz => 1},{baz=>2},{baz=>3}]}, $v);
+is_deeply($e, {'foo' => 'foo had more than 2 values.'}, "Type hash, over max_values");
+
+$e = validate({foo => [{baz => 1},{fail=>1}]}, $v);
+is_deeply($e, {'foo.baz' => 'foo.baz is required.'}, "Type hash, inner required check");


### PR DESCRIPTION
Added "canonical" field option in Respite::Base. Added t/Respite::Validate.pm.t to test the corresponding module. These tests currently pass. Added t/Respite::Base.pm.t script. Although, there are a few tests failing. TAP results are below:


t/Respite::Base.pm.t ..
ok 1 - Base lookup
ok 2 - Correct lookup for hello
ok 3 - Base lookup
ok 4 - Correct lookup for bar
ok 5 - Correct lookup for foo
ok 6 - Correct lookup for hello
ok 7 - Base lookup
ok 8 - Correct lookup for bang_child_five
not ok 9 - Correct parent

\#   Failed test 'Correct parent'
\#   at t/Respite::Base.pm.t line 130.
\#          got: undef
\#     expected: 'Respite::Base=HASH(0x7fdb82961fc8)'
ok 10 - No cached child
not ok 11 - New child each time

\#   Failed test 'New child each time'
\#   at t/Respite::Base.pm.t line 134.
\#          got: undef
\#     expected: anything else
Use of uninitialized value in string at t/Respite::Base.pm.t line 138.
not ok 12 - Correct caching

\#   Failed test 'Correct caching'
\#   at t/Respite::Base.pm.t line 138.
\#     Structures begin differing at:
\#          $got = undef
\#     $expected = HASH(0x7fdb82961cf8)
not ok 13 - Has cached child

\#   Failed test 'Has cached child'
\#   at t/Respite::Base.pm.t line 139.
Use of uninitialized value in string at t/Respite::Base.pm.t line 141.
not ok 14 - Correct caching

\#   Failed test 'Correct caching'
\#   at t/Respite::Base.pm.t line 141.
\#     Structures begin differing at:
\#          $got = undef
\#     $expected = HASH(0x7fdb83021a88)
ok 15 - Correct caching
ok 16 - No cached child
ok 17 - Base lookup
ok 18 - Base lookup
ok 19 - Created Respite::Base object
not ok 20 - Check for proper methods listing

\#   Failed test 'Check for proper methods listing'
\#   at t/Respite::Base.pm.t line 207.
\#     Structures begin differing at:
\#          $got->{methods}{baz_child_three} = 'Not documented: Invalid Respite method during AUTOLOAD: {"class":"Bam","method":"SHARE","trace":"Called from Respite::Base::__ANON__ at Respite/Base.pm line 244"}
\#     '
\#     $expected->{methods}{baz_child_three} = '3m'
Can't call method "debug" on unblessed reference at t/Respite::Base.pm.t line 207.
1..20
\# Looks like you failed 6 tests of 20.
\# Looks like your test exited with 255 just after 20.
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 6/20 subtests

Test Summary Report
\-------------------
t/Respite::Base.pm.t (Wstat: 65280 Tests: 20 Failed: 6)
  Failed tests:  9, 11-14, 20
  Non-zero exit status: 255
Files=1, Tests=20,  0 wallclock secs ( 0.03 usr  0.00 sys +  0.08 cusr  0.01 csys =  0.12 CPU)
Result: FAIL