### PR TITLE
Removed "use Debug;"

### DIFF
--- a/lib/Respite/AutoDoc.pm
+++ b/lib/Respite/AutoDoc.pm
@@ -5,7 +5,6 @@ package Respite::AutoDoc;
 use CGI::Ex::App qw(:App);
 use base qw(CGI::Ex::App);
 
-use Debug;
 use Throw qw(throw);
 use Time::HiRes ();
 use JSON ();


### PR DESCRIPTION
Respite::AutoDoc is failing to compile due to the following error:

  Can't locate Debug.pm in @INC

At first, I was thinking this needed to be changed to Data::Debug but I don't see it being used hence removing it. Feel free to let me know if this should be otherwise.